### PR TITLE
Replace legacy image imports

### DIFF
--- a/app/blog/[post]/page.tsx
+++ b/app/blog/[post]/page.tsx
@@ -1,4 +1,4 @@
-import Image from "next/legacy/image";
+import Image from "next/image";
 import Link from "next/link";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -140,7 +140,7 @@ export default async function Post({ params }: Props) {
             <div className="relative w-full h-40 pt-[52.5%]">
               <Image
                 className="rounded-xl border dark:border-zinc-800 border-zinc-100 object-cover"
-                layout="fill"
+                fill
                 src={post.coverImage?.image || fallbackImage}
                 alt={post.coverImage?.alt || post.title}
                 quality={100}
@@ -167,7 +167,7 @@ export default async function Post({ params }: Props) {
                       .height(80)
                       .url()}
                     alt={post.author.photo.alt}
-                    layout="fill"
+                    fill
                     className="dark:bg-zinc-800 bg-zinc-300 rounded-full object-cover"
                   />
                 </div>

--- a/app/components/pages/FeaturedPosts.tsx
+++ b/app/components/pages/FeaturedPosts.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import Image from "next/legacy/image";
+import Image from "next/image";
 import { postsQuery } from "@/lib/sanity.query";
 import type { PostType } from "@/types";
 import { sanityFetch } from "@/lib/sanity.client";

--- a/app/components/pages/Posts.tsx
+++ b/app/components/pages/Posts.tsx
@@ -1,4 +1,4 @@
-import Image from "next/legacy/image";
+import Image from "next/image";
 import Link from "next/link";
 import { postsQuery } from "@/lib/sanity.query";
 import { PostType } from "@/types";
@@ -35,7 +35,7 @@ export default async function Posts() {
                       src={post.coverImage?.image || fallbackImage}
                       className="dark:bg-zinc-800 bg-zinc-100 rounded-md object-cover group-hover:scale-125 duration-300"
                       alt={post.coverImage?.alt || post.title}
-                      layout="fill"
+                      fill
                       placeholder={post.coverImage ? "blur" : "empty"}
                       blurDataURL={post.coverImage?.lqip || ""}
                     />


### PR DESCRIPTION
## Summary
- migrate from `next/legacy/image` to `next/image`
- update legacy `layout` usage to new `fill` prop

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841bad668a0832b97d5406712af3b5c