### PR TITLE
Fix invalid Tailwind prefix

### DIFF
--- a/app/components/global/Theme.tsx
+++ b/app/components/global/Theme.tsx
@@ -22,7 +22,7 @@ export default function Theme() {
   return (
     <button
       onClick={toggleTheme}
-      className={`dark:bg-primary-bg bg-zinc-100 dark:text-primary-color text-zinc-500 border dark:border-zinc-800 border-zinc-200 rounded-full p-2 duration-300 transition-transform group: ${
+      className={`dark:bg-primary-bg bg-zinc-100 dark:text-primary-color text-zinc-500 border dark:border-zinc-800 border-zinc-200 rounded-full p-2 duration-300 transition-transform ${
         currentTheme === "light" ? "-rotate-180" : "rotate-0"
       }`}
       aria-label="Toggle Theme"


### PR DESCRIPTION
## Summary
- remove stray `group:` prefix in theme toggle button

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_6841bad886c8832b960112d1bd605791